### PR TITLE
Introduce `ActiveResource::WhereClause`

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -46,6 +46,7 @@ module ActiveResource
   autoload :InheritingHash
   autoload :Validations
   autoload :Collection
+  autoload :WhereClause
 
   if ActiveSupport::VERSION::STRING >= "7.1"
     def self.deprecator

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1037,12 +1037,12 @@ module ActiveResource
       # This is an alias for find(:all). You can pass in all the same
       # arguments to this method as you can to <tt>find(:all)</tt>
       def all(*args)
-        find(:all, *args)
+        WhereClause.new(self, *args)
       end
 
       def where(clauses = {})
         raise ArgumentError, "expected a clauses Hash, got #{clauses.inspect}" unless clauses.is_a? Hash
-        find(:all, params: clauses)
+        all(params: clauses)
       end
 
 

--- a/lib/active_resource/where_clause.rb
+++ b/lib/active_resource/where_clause.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  class WhereClause < BasicObject # :nodoc:
+    delegate_missing_to :resources
+
+    def initialize(resource_class, options = {})
+      @resource_class = resource_class
+      @options = options
+      @resources = nil
+      @loaded = false
+    end
+
+    def where(clauses = {})
+      all(params: clauses)
+    end
+
+    def all(options = {})
+      WhereClause.new(@resource_class, @options.deep_merge(options))
+    end
+
+    def load
+      unless @loaded
+        @resources = @resource_class.find(:all, @options)
+        @loaded = true
+      end
+
+      self
+    end
+
+    def reload
+      reset
+      load
+    end
+
+    private
+      def resources
+        load
+        @resources
+      end
+
+      def reset
+        @resources = nil
+        @loaded = false
+      end
+  end
+end


### PR DESCRIPTION
Closes [#408][]

Introduce a simple chainable `WhereClause` class inspired by [Active Record][].

All methods (including those that integrate with [Enumerable][]) are delegated to `WhereClause#all`, which itself delegates to `Base.find`.

By merging parameters through `.where`-chaining, this commit supports deferred fetching:

```ruby
people = Person.where(id: 2).where(name: "david")
  # => GET /people.json?id=2&name=david

people = Person.where(id: 2).all(params: { name: "david" })
  # => GET /people.json?id=2&name=david

people = Person.all(from: "/records.json").where(id: 2)
  # => GET /records.json?id=2
```

[#408]: https://github.com/rails/activeresource/issues/408
[Active Record]: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/where_clause.rb
[Enumerable]: https://ruby-doc.org/3.4.1/Enumerable.html